### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/ocean-common/src/main/java/com/dempe/ocean/common/codec/mqtt/Utils.java
+++ b/ocean-common/src/main/java/com/dempe/ocean/common/codec/mqtt/Utils.java
@@ -35,6 +35,8 @@ public class Utils {
     public static final byte VERSION_3_1 = 3;
     public static final byte VERSION_3_1_1 = 4;
 
+    private Utils() {}
+
     static byte readMessageType(ByteBuf in) {
         byte h1 = in.readByte();
         byte messageType = (byte) ((h1 & 0x00F0) >> 4);

--- a/ocean-common/src/main/java/com/dempe/ocean/common/pack/MarshallUtils.java
+++ b/ocean-common/src/main/java/com/dempe/ocean/common/pack/MarshallUtils.java
@@ -14,6 +14,8 @@ import java.util.*;
 public class MarshallUtils {
     private static Set<Type> supported = new HashSet<Type>();
 
+    private MarshallUtils() {}
+
     static {
         supported.add(int.class);
         supported.add(short.class);

--- a/ocean-common/src/main/java/com/dempe/ocean/common/protocol/mqtt/Utils.java
+++ b/ocean-common/src/main/java/com/dempe/ocean/common/protocol/mqtt/Utils.java
@@ -25,6 +25,8 @@ public class Utils {
 
     public static final int MAX_LENGTH_LIMIT = 268435455;
 
+    private Utils() {}
+
 //    /**
 //     * Read 2 bytes from in buffer first MSB, and then LSB returning as int.
 //     */

--- a/ocean-common/src/main/java/com/dempe/ocean/common/utils/DefConfigFactory.java
+++ b/ocean-common/src/main/java/com/dempe/ocean/common/utils/DefConfigFactory.java
@@ -17,6 +17,8 @@ import java.util.Map;
  */
 public class DefConfigFactory {
 
+    private DefConfigFactory() {}
+
     public static OceanConfig createUATConfig() {
         return createConfig(EnvEnum.UAT.getEnv());
     }

--- a/ocean-common/src/main/java/com/dempe/ocean/common/utils/PackageUtils.java
+++ b/ocean-common/src/main/java/com/dempe/ocean/common/utils/PackageUtils.java
@@ -22,6 +22,8 @@ import java.util.regex.Pattern;
 public class PackageUtils {
     public final static List<String> EMPTY_LIST = new ArrayList<String>(0);
 
+    private PackageUtils() {}
+
     /**
      * 查找指定package下的class
      *

--- a/ocean-core/src/main/java/com/dempe/ocean/core/Constants.java
+++ b/ocean-core/src/main/java/com/dempe/ocean/core/Constants.java
@@ -23,4 +23,6 @@ public class Constants {
     public static final String CLEAN_SESSION = "cleanSession";
     public static final String KEEP_ALIVE = "keepAlive";
     public static final int DEFAULT_CONNECT_TIMEOUT = 10;
+
+    private Constants() {}
 }

--- a/ocean-core/src/main/java/com/dempe/ocean/core/DebugUtils.java
+++ b/ocean-core/src/main/java/com/dempe/ocean/core/DebugUtils.java
@@ -21,6 +21,9 @@ import java.nio.ByteBuffer;
  * @author andrea
  */
 public class DebugUtils {
+
+    private DebugUtils() {}
+
     public static String payload2Str(ByteBuffer content) {
         byte[] b = new byte[content.remaining()];
         content.mark();

--- a/ocean-core/src/main/java/com/dempe/ocean/core/NettyUtils.java
+++ b/ocean-core/src/main/java/com/dempe/ocean/core/NettyUtils.java
@@ -27,6 +27,8 @@ import io.netty.util.AttributeKey;
  */
 public class NettyUtils {
 
+    private NettyUtils() {}
+
     public static final String ATTR_USERNAME = "username";
     public static final String ATTR_SESSION_STOLEN = "sessionStolen";
 

--- a/ocean-core/src/main/java/com/dempe/ocean/core/spi/impl/Utils.java
+++ b/ocean-core/src/main/java/com/dempe/ocean/core/spi/impl/Utils.java
@@ -6,6 +6,9 @@ import java.util.Map;
  * Utility static methods, like Map get with default value, or elvis operator.
  */
 public class Utils {
+
+    private Utils() {}
+
     public static <T, K> T defaultGet(Map<K, T> map, K key, T defaultValue) {
         T value = map.get(key);
         if (value != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava
