### PR TITLE
 squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/ocean-common/src/main/java/com/dempe/ocean/common/cluster/HAProxy.java
+++ b/ocean-common/src/main/java/com/dempe/ocean/common/cluster/HAProxy.java
@@ -113,7 +113,7 @@ public abstract class HAProxy<T> extends TimerTask {
      */
     private void toAvailable(NodeDetails serverInstance) {
         LOGGER.info("unAvailable server：{}", serverInstance.toString());
-        if (this.availServers.size() == 0) { //如果可用节点的列表已空,则不需考虑负载的策略
+        if (this.availServers.isEmpty()) { //如果可用节点的列表已空,则不需考虑负载的策略
             this.availServers.add(serverInstance);
         } else {
             if (this.strategy.equals(Strategy.DEFAULT)) {
@@ -231,12 +231,12 @@ public abstract class HAProxy<T> extends TimerTask {
 
         }
         if (server == null) {
-            if (availServers.size() > 0) {
+            if (!availServers.isEmpty()) {
                 // 删除当前节点
                 toUnAvailable(serverInstance);
                 initLoadBalance();
             }
-            if (availServers.size() < 1) {
+            if (availServers.isEmpty()) {
                 checkToAvailable();
             }
             server = getClient(getAvailServerInstance());
@@ -252,7 +252,7 @@ public abstract class HAProxy<T> extends TimerTask {
      * @throws Exception
      */
     public T getClient() {
-        if (availServers.size() < 1) {
+        if (availServers.isEmpty()) {
             return null;
         }
         return getClient(getAvailServerInstance());
@@ -265,7 +265,7 @@ public abstract class HAProxy<T> extends TimerTask {
      * @return
      */
     public T getClientByHashKey(String key) {
-        if (availServers.size() < 1) {
+        if (availServers.isEmpty()) {
             return null;
         }
         return getClient(getAvailServerInstance(key));
@@ -297,11 +297,11 @@ public abstract class HAProxy<T> extends TimerTask {
      * @return
      */
     public T changeClient(NodeDetails serverInstance) {
-        if (availServers.size() > 0) {
+        if (!availServers.isEmpty()) {
             toUnAvailable(serverInstance);
         }
         initLoadBalance();
-        if (availServers.size() > 0) {
+        if (!availServers.isEmpty()) {
             return getClient();
         }
         return null;

--- a/ocean-common/src/main/java/com/dempe/ocean/common/utils/PackageUtils.java
+++ b/ocean-common/src/main/java/com/dempe/ocean/common/utils/PackageUtils.java
@@ -158,7 +158,7 @@ public class PackageUtils {
      */
     private static boolean isIncluded(String name, List<String> included, List<String> excluded) {
         boolean result = false;
-        if (included.size() == 0 && excluded.size() == 0) {
+        if (included.isEmpty() && excluded.isEmpty()) {
             result = true;
         } else {
             boolean isIncluded = find(name, included);
@@ -168,7 +168,7 @@ public class PackageUtils {
             } else if (isExcluded) {
                 result = false;
             } else {
-                result = included.size() == 0;
+                result = included.isEmpty();
             }
         }
         return result;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava
